### PR TITLE
Fixes connecting NotFoundPage to App.js

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -73,14 +73,7 @@ function App() {
                 }
               />
               <Route path='/' element={<Navigate to='/home' />} />
-              <Route
-                path='/*'
-                element={
-                  <PublicRoute restricted>
-                    <NotFoundPage />
-                  </PublicRoute>
-                }
-              />
+              <Route path='/*' element={<NotFoundPage />} />
             </Routes>
           </Suspense>
 


### PR DESCRIPTION
Убрал в подключении обёртку публичного пути. 
Если используется или публичная, или приватная обёртка, то то переход на NotFoundPage происходит только в соответсвующем статусе (или приватный, или публичный), а в противоположном переход не работает. Именно поэтому ты, Вова, и не мог попасть на страницу NotFoundPage: ты был залогинен, а переход работал только в разлогиненом состоянии по публичным раутам.
Если не используем обёртку, то переход на NotFoundPage происходит в любом статусе.